### PR TITLE
Added `CGO_ENABLED=0` env variable for statically linked binary.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ WORKDIR /app
 COPY . .
 
 # Build binary
-RUN go build -o main main.go
+RUN CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64 \
+    go build -o main main.go
 
 ###############################################################
 # Final
@@ -26,4 +29,4 @@ COPY --from=build /app/main ./main
 
 EXPOSE 8000
 
-ENTRYPOINT [ "./main" ]
+ENTRYPOINT ["./main"]


### PR DESCRIPTION
## Description

For multistage builds using `alpine` as your final layer, there's apparently a known issue with bash outputting a `no such file or directory` when attempting to execute dynamically linked binaries compiled on another Linux distro (when the file does indeed exist on the file system). 

Adding `CGO_ENABLED=0` as an environment variable configures Go to build a statically linked binary - this fixes the issue. 

See https://jvns.ca/blog/2021/11/17/debugging-a-weird--file-not-found--error/ for an excellent walk through. 